### PR TITLE
Fixed bug with different names of hash table's implementation class in hash_table.h and test.cpp

### DIFF
--- a/tasks/containers/hash_map/CMakeLists.txt
+++ b/tasks/containers/hash_map/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_executable_test(test_hash_map test.cpp hash_map.h)
+add_executable_test(test_hash_map test.cpp hash_table.h)

--- a/tasks/containers/hash_map/hash_table.h
+++ b/tasks/containers/hash_map/hash_table.h
@@ -5,7 +5,7 @@
 #include <cstddef>
 
 template <typename Key, typename Value>
-class HashMap {
+class HashTable {
 public:
     struct Entry {
         Key key;

--- a/tasks/containers/hash_map/test.cpp
+++ b/tasks/containers/hash_map/test.cpp
@@ -2,7 +2,7 @@
 
 #include "random_utils.h"
 
-#include "hash_map.h"
+#include "hash_table.h"
 
 #include <unordered_map>
 


### PR DESCRIPTION
В .h файле название класса хештаблицы не соответствовало названию класса в файле с тестами. Переименовал класс в файле .h на тот, который указан в tests.cpp, переименовал сам файл.h и поменял CMakeLists и tests.cpp для корректной работы 